### PR TITLE
dvdkv - add language=raw to mediainfo cmd

### DIFF
--- a/dvdkv.py
+++ b/dvdkv.py
@@ -9,12 +9,12 @@ def get_dvd_mount_point():
 	return result.split(':')[-1].strip()
 
 def extract_dvd_metadata(info):
-	cmd = ['mediainfo','--Output=XML','-f',info['mnt_point'],'2>&1']
+	cmd = ['mediainfo','--Output=XML','-f','language=raw',info['mnt_point'],'2>&1']
 	with open(info['basepath']+'_dvd.metadata.xml', "w") as file:
 		subprocess.call(cmd,stdout=file)
 
 def extract_iso_metadata(info)
-	cmd = ['mediainfo','--Output=XML','-f',info['iso_path'],'2>&1']
+	cmd = ['mediainfo','--Output=XML','-f','language=raw',info['iso_path'],'2>&1']
 	with open(info['basepath']+'_iso.metadata.xml', "w") as file:
 		subprocess.call(cmd,stdout=file)
 

--- a/dvdkv.py
+++ b/dvdkv.py
@@ -9,12 +9,12 @@ def get_dvd_mount_point():
 	return result.split(':')[-1].strip()
 
 def extract_dvd_metadata(info):
-	cmd = ['mediainfo','--Output=XML','-f','language=raw',info['mnt_point'],'2>&1']
+	cmd = ['mediainfo','--Output=XML','-f','--Language=raw',info['mnt_point'],'2>&1']
 	with open(info['basepath']+'_dvd.metadata.xml', "w") as file:
 		subprocess.call(cmd,stdout=file)
 
 def extract_iso_metadata(info)
-	cmd = ['mediainfo','--Output=XML','-f','language=raw',info['iso_path'],'2>&1']
+	cmd = ['mediainfo','--Output=XML','-f','--Language=raw',info['iso_path'],'2>&1']
 	with open(info['basepath']+'_iso.metadata.xml', "w") as file:
 		subprocess.call(cmd,stdout=file)
 


### PR DESCRIPTION
Hi Piaras, 

Lovely looking script, I must investigate the click module.
I'm sending this as I think `--Language=raw` is very useful when also using `-f`. It allows for more specific xml extracting later, for example, HH:MM:SS:FF - will always be DurationString4 etc..

It might mess with your workflow, so this might be useless for you, but thought I'd send it regardless.

Here's without `language=raw`

```
<Duration>759</Duration>
<Duration>759ms</Duration>
<Duration>759ms</Duration>
<Duration>759ms</Duration>
<Duration>00:00:00.759</Duration>
<Duration>00:00:00:36</Duration>
<Duration>00:00:00.759 (00:00:00:36)</Duration>
```

and with:

```

<Duration>759</Duration>
<Duration_String>759ms</Duration_String>
<Duration_String1>759ms</Duration_String1>
<Duration_String2>759ms</Duration_String2>
<Duration_String3>00:00:00.759</Duration_String3>
<Duration_String4>00:00:00:36</Duration_String4>
<Duration_String5>00:00:00.759 (00:00:00:36)</Duration_String5>
```
